### PR TITLE
Rename VehicleLocationEvent status field

### DIFF
--- a/event_schemas/VehicleLocation.proto
+++ b/event_schemas/VehicleLocation.proto
@@ -6,11 +6,11 @@ import "google/protobuf/timestamp.proto";
 
 message VehicleLocationEvent {
   required string agencyId = 1;
-  required string vehicleId = 2;
+  required int32 vehicleId = 2;
   required google.protobuf.Timestamp timestamp = 3;
-  required float latitude = 4;
+  optional float latitude = 4;
   required float longitude = 5;
-  required string status = 6;
+  required string vehicleStATUS = 6;
   optional string routeId = 7;
   optional uint32 occupancyLevel = 8;
 }


### PR DESCRIPTION
Testing the tutorial before 10/23/23 release. Using the Fake OBA Unstable account. 

Rename the `status` field to `vehicleStatus` in `VehicleLocationEvent` data.